### PR TITLE
Move operator<< for Joint and Device into namespace hpp::model

### DIFF
--- a/include/hpp/model/device.hh
+++ b/include/hpp/model/device.hh
@@ -358,9 +358,9 @@ namespace hpp {
       ExtraConfigSpace extraConfigSpace_;
       DeviceWkPtr_t weakPtr_;
     }; // class Device
+
+    std::ostream& operator<< (std::ostream& os, const hpp::model::Device& device);
   } // namespace model
 } // namespace hpp
-
-std::ostream& operator<< (std::ostream& os, const hpp::model::Device& device);
 
 #endif // HPP_MODEL_DEVICE_HH

--- a/include/hpp/model/joint.hh
+++ b/include/hpp/model/joint.hh
@@ -530,11 +530,11 @@ namespace hpp {
       mutable fcl::Vec3f com_;
     }; // class JointTranslation
 
+    std::ostream& operator<< (std::ostream& os, const hpp::model::Joint& joint);
   } // namespace model
 } // namespace hpp
 
 namespace fcl {
   std::ostream& operator<< (std::ostream& os , const fcl::Transform3f& trans);
 }
-std::ostream& operator<< (std::ostream& os, const hpp::model::Joint& joint);
 #endif // HPP_MODEL_JOINT_HH

--- a/src/device.cc
+++ b/src/device.cc
@@ -570,10 +570,10 @@ namespace hpp {
 
       return os;
     }
+
+    std::ostream& operator<<(std::ostream& os, const hpp::model::Device& device)
+    {
+      return device.print (os);
+    }
   } // namespace model
 } // namespace hpp
-
-std::ostream& operator<<(std::ostream& os, const hpp::model::Device& device)
-{
-  return device.print (os);
-}

--- a/src/joint.cc
+++ b/src/joint.cc
@@ -665,6 +665,11 @@ namespace hpp {
     template class JointTranslation <1>;
     template class JointTranslation <2>;
     template class JointTranslation <3>;
+
+    std::ostream& operator<< (std::ostream& os, const hpp::model::Joint& joint)
+    {
+      return joint.display (os);
+    }
   } // namespace model
 } // namespace hpp
 
@@ -682,9 +687,3 @@ namespace fcl {
     return os;
   }
 }
-
-std::ostream& operator<< (std::ostream& os, const hpp::model::Joint& joint)
-{
-  return joint.display (os);
-}
-


### PR DESCRIPTION
Move function `std::ostream& operator<< (std::ostream& os, const hpp::model::A&)` to namespace `hpp::model`, the namespace containing class A.
