### PR TITLE
Devel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,11 @@ ADD_REQUIRED_DEPENDENCY("hpp-fcl >= 0.2.9")
 # Compile documentation
 CONFIGURE_FILE(doc/main.hh.in doc/main.hh)
 
-# Add dependency toward hpp-model library in pkg-config file.
-PKG_CONFIG_APPEND_LIBS("hpp-model")
-
 ADD_SUBDIRECTORY(src)
 ADD_SUBDIRECTORY(tests)
+
+# Add dependency toward hpp-model library in pkg-config file.
+PKG_CONFIG_APPEND_LIBS("hpp-model")
 
 SETUP_PROJECT_FINALIZE()
 SETUP_PROJECT_CPACK()

--- a/include/hpp/model/configuration.hh
+++ b/include/hpp/model/configuration.hh
@@ -105,6 +105,26 @@ namespace hpp {
       result.tail (dim) = q2.tail (dim) - q1.tail (dim);
     }
 
+    /// Distance between two configuration.
+    ///
+    /// \param robot robot that describes the kinematic chain
+    /// \param q1 first configuration,
+    /// \param q2 second configuration,
+    inline value_type distance (const DevicePtr_t& robot, ConfigurationIn_t q1,
+			  ConfigurationIn_t q2)
+    {
+      value_type result = 0;
+      const JointVector_t& jv (robot->getJointVector ());
+      for (model::JointVector_t::const_iterator itJoint = jv.begin ();
+	   itJoint != jv.end (); itJoint++) {
+	size_type iC = (*itJoint)->rankInConfiguration ();
+        result += (*itJoint)->configuration ()->squaredDistance (q1, q2, iC);
+      }
+      const size_type& dim = robot->extraConfigSpace().dimension();
+      result += (q2.tail (dim) - q1.tail (dim)).squaredNorm ();
+      return sqrt (result);
+    }
+
     /// Normalize configuration
     ///
     /// Configuration space is a represented by a sub-manifold of a vector

--- a/include/hpp/model/configuration.hh
+++ b/include/hpp/model/configuration.hh
@@ -86,8 +86,10 @@ namespace hpp {
     /// \param q1 first configuration,
     /// \param q2 second configuration,
     /// \retval result difference as a vector \f$\textbf{v}\f$ such that
-    /// q2 is the result of method integrate from q1 with vector
+    /// q1 is the result of method integrate from q2 with vector
     /// \f$\textbf{v}\f$
+    /// \note If the configuration space is a vector space, this is
+    /// \f$\textbf{v} = q_1 - q_2\f$
     void inline difference (const DevicePtr_t& robot, ConfigurationIn_t q1,
 			    ConfigurationIn_t q2, vectorOut_t result)
     {

--- a/include/hpp/model/fwd.hh
+++ b/include/hpp/model/fwd.hh
@@ -60,8 +60,8 @@ namespace hpp {
     typedef matrix_t::Index size_type;
     typedef fcl::Matrix3f matrix3_t;
     typedef fcl::Vec3f vector3_t;
-    typedef Eigen::Matrix <value_type, 6, Eigen::Dynamic> JointJacobian_t;
-    typedef Eigen::Matrix <value_type, 3, Eigen::Dynamic> ComJacobian_t;
+    typedef Eigen::Matrix <value_type, 6, Eigen::Dynamic, Eigen::RowMajor> JointJacobian_t;
+    typedef Eigen::Matrix <value_type, 3, Eigen::Dynamic, Eigen::RowMajor> ComJacobian_t;
     typedef Eigen::Block <JointJacobian_t, 3, Eigen::Dynamic>
     HalfJointJacobian_t;
 

--- a/include/hpp/model/joint-configuration.hh
+++ b/include/hpp/model/joint-configuration.hh
@@ -66,6 +66,14 @@ namespace hpp {
 				const size_type& index,
 				ConfigurationOut_t result) = 0;
 
+      /// Squared distance between two configurations of the joint
+      /// \param q1, q2 two configurations of the robot
+      /// \param index index of first component of q1 and q2 corresponding to
+      /// the joint.
+      virtual value_type squaredDistance (ConfigurationIn_t q1,
+				          ConfigurationIn_t q2,
+				          const size_type& index) const = 0;
+
       /// Distance between two configurations of the joint
       /// \param q1, q2 two configurations of the robot
       /// \param index index of first component of q1 and q2 corresponding to
@@ -160,6 +168,9 @@ namespace hpp {
       virtual value_type distance (ConfigurationIn_t q1,
 				   ConfigurationIn_t q2,
 				   const size_type& index) const;
+      value_type squaredDistance (ConfigurationIn_t q1,
+				  ConfigurationIn_t q2,
+				  const size_type& index) const;
 
       virtual void integrate (ConfigurationIn_t q,
 			      vectorIn_t v,
@@ -198,6 +209,9 @@ namespace hpp {
       virtual value_type distance (ConfigurationIn_t q1,
 				   ConfigurationIn_t q2,
 				   const size_type& index) const;
+      value_type squaredDistance (ConfigurationIn_t q1,
+				  ConfigurationIn_t q2,
+				  const size_type& index) const;
       virtual void integrate (ConfigurationIn_t q,
 			      vectorIn_t v,
 			      const size_type& indexConfig,
@@ -311,6 +325,9 @@ namespace hpp {
 			  ConfigurationOut_t result);
 	value_type distance (ConfigurationIn_t q1, ConfigurationIn_t q2,
 			     const size_type& index) const;
+        value_type squaredDistance (ConfigurationIn_t q1,
+				    ConfigurationIn_t q2,
+				    const size_type& index) const;
 	void integrate (ConfigurationIn_t q, vectorIn_t v,
 			const size_type& indexConfig,
 			const size_type& indexVelocity,
@@ -338,6 +355,9 @@ namespace hpp {
 			  ConfigurationOut_t result);
 	value_type distance (ConfigurationIn_t q1, ConfigurationIn_t q2,
 			     const size_type& index) const;
+        value_type squaredDistance (ConfigurationIn_t q1,
+				    ConfigurationIn_t q2,
+				    const size_type& index) const;
 	void integrate (ConfigurationIn_t q, vectorIn_t v,
 			const size_type& indexConfig,
 			const size_type& indexVelocity,
@@ -375,6 +395,9 @@ namespace hpp {
       virtual value_type distance (ConfigurationIn_t q1,
 				   ConfigurationIn_t q2,
 				   const size_type& index) const;
+      value_type squaredDistance (ConfigurationIn_t q1,
+				  ConfigurationIn_t q2,
+				  const size_type& index) const;
 
       virtual void integrate (ConfigurationIn_t q,
 			      vectorIn_t v,

--- a/src/joint-configuration.cc
+++ b/src/joint-configuration.cc
@@ -117,6 +117,13 @@ namespace hpp {
     {
     }
 
+    value_type AnchorJointConfig::squaredDistance (ConfigurationIn_t,
+					           ConfigurationIn_t,
+					           const size_type&) const
+    {
+      return 0;
+    }
+
     value_type AnchorJointConfig::distance (ConfigurationIn_t,
 					    ConfigurationIn_t,
 					    const size_type&) const
@@ -152,6 +159,8 @@ namespace hpp {
     }
 
     /// Compute quaternion and angle from a SO(3) joint configuration
+    /// \note this angle corresponds to the angle between q1 and q2, in \f$ \mathbb{R}^4 \f$.
+    ///       The angle of the rotation going from q1 to q2 is half this angle.
     ///
     /// \param q1, q2, robot configurations
     /// \param index index of joint configuration in robot configuration vector
@@ -199,6 +208,14 @@ namespace hpp {
       }
     }
 
+    value_type SO3JointConfig::squaredDistance (ConfigurationIn_t q1,
+                                                ConfigurationIn_t q2,
+                                                const size_type& index) const
+    {
+      const value_type d (distance (q1, q2, index));
+      return d*d;
+    }
+
     value_type SO3JointConfig::distance (ConfigurationIn_t q1,
 					 ConfigurationIn_t q2,
 					 const size_type& index) const
@@ -207,7 +224,7 @@ namespace hpp {
       value_type theta = angleBetweenQuaternions (q1, q2, index, cosIsNegative);
       assert (theta >= 0);
       assert (M_PI - theta >= 0);
-      return (cosIsNegative) ? M_PI - theta : theta;
+      return 2 * (cosIsNegative ? M_PI - theta : theta);
     }
 
     void SO3JointConfig::integrate (ConfigurationIn_t q,
@@ -300,6 +317,13 @@ namespace hpp {
       result.segment <dimension> (index) =
 	(1-u) * q1.segment <dimension> (index) +
 	u * q2.segment <dimension> (index);
+    }
+
+    template <size_type dimension>
+    value_type TranslationJointConfig <dimension>::squaredDistance
+    (ConfigurationIn_t q1, ConfigurationIn_t q2, const size_type& index) const
+    {
+      return (q2.segment <dimension> (index) - q1.segment <dimension> (index)).squaredNorm ();
     }
 
     template <size_type dimension>
@@ -401,6 +425,14 @@ namespace hpp {
 	}
       }
 
+      value_type UnBounded::squaredDistance (ConfigurationIn_t q1,
+				             ConfigurationIn_t q2,
+				             const size_type& index) const
+      {
+        const value_type d (distance (q1, q2, index));
+	return d*d;
+      }
+
       value_type UnBounded::distance (ConfigurationIn_t q1,
 				      ConfigurationIn_t q2,
 				      const size_type& index) const
@@ -473,6 +505,14 @@ namespace hpp {
       {
 	// linearly interpolate
 	result [index] = (1-u) * q1 [index] + u * q2 [index];
+      }
+
+      value_type Bounded::squaredDistance (ConfigurationIn_t q1,
+                                           ConfigurationIn_t q2,
+                                           const size_type& index) const
+      {
+	// linearly interpolate
+        return (q2.segment<1>(index) - q1.segment<1>(index)).squaredNorm ();
       }
 
       value_type Bounded::distance (ConfigurationIn_t q1, ConfigurationIn_t q2,


### PR DESCRIPTION
A special care must be taken for quaternions.

The previous version of member function `distance` and `difference` of `SO3JointConfig` were not consistent because `|| difference(q1, q2) || = 2 * distance (q1, q2)`. Geometrically, the previous distance was the angle between the quaternions as elements of the vector space R^4. The proposed implementation of `distance` returns the rotation angle of the rotation going from q1 to q2.