### PR TITLE
Fix bug: set Device::upToDate_ to false when the root joint position …

### DIFF
--- a/src/device.cc
+++ b/src/device.cc
@@ -465,6 +465,7 @@ namespace hpp {
 	throw std::runtime_error ("The device has no root joint.");
       }
       rootJoint_->positionInParentFrame_ = position;
+      upToDate_ = false;
     }
 
     JointPtr_t Device::rootJoint () const


### PR DESCRIPTION
…is changed

* otherwise the kinematic will not be update when calling
* computeForwardKinematics