### PR TITLE
Method integrate returns a vector of bool to indicate "Out of bounds"

### DIFF
--- a/include/hpp/model/fwd.hh
+++ b/include/hpp/model/fwd.hh
@@ -48,6 +48,7 @@ namespace hpp {
     enum Request_t {COLLISION, DISTANCE};
 
     typedef double value_type;
+    typedef std::vector<bool> vectorBool_t;
     typedef Eigen::Matrix <value_type, Eigen::Dynamic, 1> vector_t;
     typedef vector_t Configuration_t;
     typedef Eigen::Ref <const Configuration_t> ConfigurationIn_t;

--- a/include/hpp/model/joint-configuration.hh
+++ b/include/hpp/model/joint-configuration.hh
@@ -90,13 +90,18 @@ namespace hpp {
       /// \param indexVelocity index of first component of v corresponding to
       ///        the joint
       /// \retval result write joint configuration in
+      /// \retval saturate vector of boolean set to True on DOF which where
+      ///         saturated (integration result would have been out of
+      ///         boundaries otherwise).
+      /// \return true if at least one parameter saturated.
       /// result [indexConfig:indexConfig + joint config size]
       /// \note if result is beying bounds, return active bound.
-      virtual void integrate (ConfigurationIn_t q,
+      virtual bool integrate (ConfigurationIn_t q,
 			      vectorIn_t v,
 			      const size_type& indexConfig,
 			      const size_type& indexVelocity,
-			      ConfigurationOut_t result) const = 0;
+			      ConfigurationOut_t result,
+                              vectorBool_t& saturate) const = 0;
 
       /// Difference between two configurations
       ///
@@ -172,11 +177,12 @@ namespace hpp {
 				  ConfigurationIn_t q2,
 				  const size_type& index) const;
 
-      virtual void integrate (ConfigurationIn_t q,
+      virtual bool integrate (ConfigurationIn_t q,
 			      vectorIn_t v,
 			      const size_type& indexConfig,
 			      const size_type& indexVelocity,
-			      ConfigurationOut_t result) const;
+			      ConfigurationOut_t result,
+                              vectorBool_t& saturate) const;
       virtual void difference (ConfigurationIn_t q1,
 			       ConfigurationIn_t q2,
 			       const size_type& indexConfig,
@@ -212,11 +218,12 @@ namespace hpp {
       value_type squaredDistance (ConfigurationIn_t q1,
 				  ConfigurationIn_t q2,
 				  const size_type& index) const;
-      virtual void integrate (ConfigurationIn_t q,
+      virtual bool integrate (ConfigurationIn_t q,
 			      vectorIn_t v,
 			      const size_type& indexConfig,
 			      const size_type& indexVelocity,
-			      ConfigurationOut_t result) const;
+			      ConfigurationOut_t result,
+                              vectorBool_t& saturate) const;
       /// Difference between two configurations
       ///
       /// \param q1 configuration,
@@ -269,11 +276,12 @@ namespace hpp {
       virtual value_type distance (ConfigurationIn_t q1,
 				   ConfigurationIn_t q2,
 				   const size_type& index) const = 0;
-      virtual void integrate (ConfigurationIn_t q,
+      virtual bool integrate (ConfigurationIn_t q,
 			      vectorIn_t v,
 			      const size_type& indexConfig,
 			      const size_type& indexVelocity,
-			      ConfigurationOut_t result) const = 0;
+			      ConfigurationOut_t result,
+                              vectorBool_t& saturate) const = 0;
 
       /// Difference between two configurations
       ///
@@ -328,10 +336,11 @@ namespace hpp {
         value_type squaredDistance (ConfigurationIn_t q1,
 				    ConfigurationIn_t q2,
 				    const size_type& index) const;
-	void integrate (ConfigurationIn_t q, vectorIn_t v,
+	bool integrate (ConfigurationIn_t q, vectorIn_t v,
 			const size_type& indexConfig,
 			const size_type& indexVelocity,
-			ConfigurationOut_t result) const;
+			ConfigurationOut_t result,
+                        vectorBool_t& saturate) const;
 	void difference (ConfigurationIn_t q1, ConfigurationIn_t q2,
 			 const size_type& indexConfig,
 			 const size_type& indexVelocity,
@@ -358,10 +367,11 @@ namespace hpp {
         value_type squaredDistance (ConfigurationIn_t q1,
 				    ConfigurationIn_t q2,
 				    const size_type& index) const;
-	void integrate (ConfigurationIn_t q, vectorIn_t v,
+	bool integrate (ConfigurationIn_t q, vectorIn_t v,
 			const size_type& indexConfig,
 			const size_type& indexVelocity,
-			ConfigurationOut_t result) const;
+			ConfigurationOut_t result,
+                        vectorBool_t& saturate) const;
 	void difference (ConfigurationIn_t q1, ConfigurationIn_t q2,
 			 const size_type& indexConfig,
 			 const size_type& indexVelocity,
@@ -399,11 +409,12 @@ namespace hpp {
 				  ConfigurationIn_t q2,
 				  const size_type& index) const;
 
-      virtual void integrate (ConfigurationIn_t q,
+      virtual bool integrate (ConfigurationIn_t q,
 			      vectorIn_t v,
 			      const size_type& indexConfig,
 			      const size_type& indexVelocity,
-			      ConfigurationOut_t result) const;
+			      ConfigurationOut_t result,
+            vectorBool_t& saturate) const;
       /// Difference between two configurations
       ///
       /// \param q1 configuration,


### PR DESCRIPTION
The vector of boolean has **the size of velocities** and tells whether the result of integrating a specific velocity value is beyond the configuration parameter bounds.

It could be of **the size of configurations**. I chose velocity size because:
- I do not see any specific reason for one or the other,
- it is more convenient for my specific use case.

@florent-lamiraux, @stonneau: do you see any specific reason in favour of one of the 2 options ?