### PR TITLE
Fix cmake packaging for executable targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,13 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 SET(CXX_DISABLE_WERROR TRUE)
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/boost.cmake)
-INCLUDE(cmake/eigen.cmake)
 INCLUDE(cmake/cpack.cmake)
 
 SET(PROJECT_NAME hpp-model)
 SET(PROJECT_DESCRIPTION
   "Implementation of hybrid geometric and dynamic humanoid robots"
   )
-SET(PROJECT_URL "")
+SET(PROJECT_URL "https://github.com/humanoid-path-planner/hpp-model")
 
 # Where to compile shared objects
 SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,8 +40,10 @@ PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} eigen3)
 IF (ASSIMP_FOUND)
   ADD_EXECUTABLE(hpp-check-mesh-file
     check_mesh_file.cc)
-  PKG_CONFIG_USE_DEPENDENCY(hpp-check-mesh-file assimp)
   TARGET_LINK_LIBRARIES(hpp-check-mesh-file ${LIBRARY_NAME})
+  PKG_CONFIG_USE_DEPENDENCY(hpp-check-mesh-file assimp)
+  PKG_CONFIG_USE_DEPENDENCY(hpp-check-mesh-file hpp-fcl)
+  PKG_CONFIG_USE_DEPENDENCY(hpp-check-mesh-file hpp-util)
   INSTALL(TARGETS hpp-check-mesh-file DESTINATION bin)
 ENDIF (ASSIMP_FOUND)
 


### PR DESCRIPTION
The linkage of executables is not transitive between a library and a linked executable. We must specify the explicit dependencies.